### PR TITLE
Fix effect_orphan error by wrapping module-scope $effect

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,35 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "pcpc (dev)",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@maber/pcpc", "dev", "--", "--port", "5173"],
+      "port": 5173
+    },
+    {
+      "name": "blackjack (dev)",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@maber/blackjack", "dev", "--", "--port", "5174"],
+      "port": 5174
+    },
+    {
+      "name": "landing (dev)",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@maber/landing", "dev", "--", "--port", "5175"],
+      "port": 5175
+    },
+    {
+      "name": "portfolio (dev)",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@maber/portfolio", "dev", "--", "--port", "5176"],
+      "port": 5176
+    },
+    {
+      "name": "all apps (turbo dev)",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
+      "port": 5173
+    }
+  ]
+}

--- a/apps/pcpc/src/lib/stores/cards.svelte.ts
+++ b/apps/pcpc/src/lib/stores/cards.svelte.ts
@@ -90,19 +90,23 @@ function createCardsStore(): CardsStore {
   }
 
   /**
-   * Effect: React to selectedSet changes and load cards
+   * Effect: React to selectedSet changes and load cards.
+   * Uses $effect.root() because this store is created at module scope,
+   * outside of any Svelte component tree.
    */
   if (browser) {
-    $effect(() => {
-      const selectedSet = setsStore.selectedSet;
-      if (selectedSet) {
-        loadCardsForSet(selectedSet.id).catch((err) => {
-          log.error(`Failed to auto-load cards: ${err}`);
-        });
-      } else {
-        cardsInSet = [];
-        selectedCard = null;
-      }
+    $effect.root(() => {
+      $effect(() => {
+        const selectedSet = setsStore.selectedSet;
+        if (selectedSet) {
+          loadCardsForSet(selectedSet.id).catch((err) => {
+            log.error(`Failed to auto-load cards: ${err}`);
+          });
+        } else {
+          cardsInSet = [];
+          selectedCard = null;
+        }
+      });
     });
   }
 


### PR DESCRIPTION
## Changes

- **cards.svelte.ts**: Wrap module-scope `$effect` in `$effect.root()` to resolve the `effect_orphan` error. Module-scope effects must be wrapped in `$effect.root()` since they exist outside of any Svelte component tree.

- **.claude/launch.json**: Add Claude launch configuration with dev server shortcuts for all apps (pcpc, blackjack, landing, portfolio) and turbo dev option.

## Details

The `$effect` in the cards store was being created at module scope, which Svelte now requires to be wrapped in `$effect.root()`. This ensures proper effect lifecycle management outside of component boundaries.