### PR TITLE
fix(pcpc): remove $effect loop causing infinite card reloads (#3)

### DIFF
--- a/apps/pcpc/src/lib/stores/cards.svelte.ts
+++ b/apps/pcpc/src/lib/stores/cards.svelte.ts
@@ -1,13 +1,15 @@
 /**
  * Cards Store - Card data management using Svelte 5 runes
- * Reacts to selectedSet changes in setsStore
+ *
+ * Card loading is triggered imperatively by setsStore.selectSet(),
+ * NOT via a reactive $effect. This avoids an infinite loop where
+ * $effect -> loadCardsForSet -> mutate $state -> re-trigger $effect.
  */
 
 import { browser } from '$app/environment';
 import type { PokemonCard } from '$lib/types';
 import { api } from '$lib/services/api';
 import { db } from '$lib/services/db';
-import { setsStore } from './sets.svelte';
 import { createContextLogger } from '$lib/services/logger';
 
 const log = createContextLogger('cardStore');
@@ -36,7 +38,8 @@ function createCardsStore(): CardsStore {
   let cardName: string = $derived(selectedCard?.name || '');
 
   /**
-   * Load cards for a specific set
+   * Load cards for a specific set.
+   * Called imperatively from setsStore.selectSet() — not from a reactive $effect.
    */
   async function loadCardsForSet(setId: string): Promise<void> {
     if (isLoadingCards) return;
@@ -96,27 +99,6 @@ function createCardsStore(): CardsStore {
   function resetCards() {
     cardsInSet = [];
     selectedCard = null;
-  }
-
-  /**
-   * Effect: React to selectedSet changes and load cards.
-   * Uses $effect.root() because this store is created at module scope,
-   * outside of any Svelte component tree.
-   */
-  if (browser) {
-    $effect.root(() => {
-      $effect(() => {
-        const selectedSet = setsStore.selectedSet;
-        if (selectedSet) {
-          loadCardsForSet(selectedSet.id).catch((err) => {
-            log.error(`Failed to auto-load cards: ${err}`);
-          });
-        } else {
-          cardsInSet = [];
-          selectedCard = null;
-        }
-      });
-    });
   }
 
   return {


### PR DESCRIPTION
## Summary

Fixes the infinite `$effect` loop in `cardsStore` that caused 1000+ console messages per second when selecting a set (Issue #3).

## Root Cause

Card loading was triggered from **two places simultaneously**:

1. `setsStore.selectSet()` directly calls `cardsStore.loadCardsForSet(set.id)` (imperative path)
2. `cardsStore`'s `$effect.root()` watches `setsStore.selectedSet` and calls `loadCardsForSet()` (reactive path)

The `$effect` would re-trigger on every `$state` mutation inside `loadCardsForSet()` (`cardsInSet`, `selectedCard`, `isLoadingCards`), causing an infinite loop. The `isLoadingCards` guard failed because IndexedDB cache hits resolve fast enough that the flag resets before the next effect cycle.

## Fix

Remove the `$effect.root()` block entirely. The imperative path through `setsStore.selectSet()` already handles card loading — the reactive path was redundant and harmful.

## Testing

- Verified the loop reproduces on `main` (1,396 console messages after one set selection)
- After fix: single `Loading → Loaded` log pair per set selection
- Full smoke test: set select → card select → get price flow works correctly