### PR TITLE
fix: map Scrydex API snake_case pagination fields to camelCase (#10)

### DIFF
--- a/apps/pcpc/src/lib/server/services/scrydexApi.ts
+++ b/apps/pcpc/src/lib/server/services/scrydexApi.ts
@@ -74,11 +74,42 @@ export interface ScrydexPrice {
   };
 }
 
+/**
+ * Raw paginated response shape from the Scrydex API (snake_case).
+ * The API returns: data, page, page_size, count, total_count
+ */
+interface ScrydexRawPaginatedResponse<T> {
+  data: T[];
+  page: number;
+  page_size: number;
+  count: number;
+  total_count: number;
+}
+
+/**
+ * Internal paginated response (camelCase).
+ * All code outside this file uses this shape.
+ */
 export interface ScrydexPaginatedResponse<T> {
   data: T[];
   page: number;
   pageSize: number;
+  count: number;
   totalCount: number;
+}
+
+/**
+ * Map the raw snake_case API response to our internal camelCase type.
+ * This is the single boundary where the casing conversion happens.
+ */
+function mapPaginatedResponse<T>(raw: ScrydexRawPaginatedResponse<T>): ScrydexPaginatedResponse<T> {
+  return {
+    data: raw.data,
+    page: raw.page,
+    pageSize: raw.page_size,
+    count: raw.count,
+    totalCount: raw.total_count,
+  };
 }
 
 export interface ScrydexUsage {
@@ -238,6 +269,15 @@ export class ScrydexApiService implements IScrydexApiService {
     throw lastError || new Error(`Scrydex API request failed after ${maxRetries} retries`);
   }
 
+  /**
+   * Fetch a paginated endpoint, mapping the raw snake_case response
+   * to our internal camelCase ScrydexPaginatedResponse type.
+   */
+  private async fetchPaginated<T>(url: string): Promise<ScrydexPaginatedResponse<T>> {
+    const raw = await this.fetchWithRetry<ScrydexRawPaginatedResponse<T>>(url);
+    return mapPaginatedResponse(raw);
+  }
+
   // ─── Expansion endpoints ──────────────────────────────────────────────────
 
   async getAllExpansions(language: string = 'en'): Promise<ScrydexExpansion[]> {
@@ -276,13 +316,17 @@ export class ScrydexApiService implements IScrydexApiService {
       let totalCount = Infinity;
 
       while (allExpansions.length < totalCount) {
-        const response = await this.fetchWithRetry<
-          ScrydexPaginatedResponse<ScrydexExpansion>
-        >(`${this.baseUrl}/${language}/expansions?page=${currentPage}&page_size=${fetchPageSize}`);
+        const response = await this.fetchPaginated<ScrydexExpansion>(
+          `${this.baseUrl}/${language}/expansions?page=${currentPage}&page_size=${fetchPageSize}`
+        );
 
         allExpansions.push(...response.data);
         totalCount = response.totalCount;
         currentPage++;
+
+        console.log(
+          `[ScrydexApiService] Expansions page ${response.page}: ${response.data.length} items, ${allExpansions.length}/${totalCount} total`
+        );
 
         // Safety: break if we got an empty page (shouldn't happen, but prevents infinite loops)
         if (response.data.length === 0) break;
@@ -355,14 +399,12 @@ export class ScrydexApiService implements IScrydexApiService {
         `[ScrydexApiService] Fetching cards for expansion ${expansionId} (page ${page}, pageSize ${pageSize})`
       );
 
-      const response = await this.fetchWithRetry<
-        ScrydexPaginatedResponse<ScrydexCard>
-      >(
+      const response = await this.fetchPaginated<ScrydexCard>(
         `${this.baseUrl}/expansions/${expansionId}/cards?page=${page}&page_size=${pageSize}`
       );
 
       console.log(
-        `[ScrydexApiService] Retrieved ${response.data.length} cards for expansion ${expansionId}`
+        `[ScrydexApiService] Retrieved ${response.data.length} cards for expansion ${expansionId} (page ${response.page}, totalCount ${response.totalCount})`
       );
 
       this.cardsCache[cacheKey] = {
@@ -404,6 +446,10 @@ export class ScrydexApiService implements IScrydexApiService {
       allCards.push(...response.data);
       totalCount = response.totalCount;
       currentPage++;
+
+      console.log(
+        `[ScrydexApiService] Cards page ${response.page}: ${response.data.length} items, ${allCards.length}/${totalCount} total`
+      );
 
       // Safety: break if we got an empty page
       if (response.data.length === 0) break;
@@ -481,9 +527,9 @@ export class ScrydexApiService implements IScrydexApiService {
         page_size: String(pageSize),
       });
 
-      const response = await this.fetchWithRetry<
-        ScrydexPaginatedResponse<ScrydexCard>
-      >(`${this.baseUrl}/${language}/cards/search?${params}`);
+      const response = await this.fetchPaginated<ScrydexCard>(
+        `${this.baseUrl}/${language}/cards/search?${params}`
+      );
 
       console.log(
         `[ScrydexApiService] Search returned ${response.data.length} of ${response.totalCount} results`
@@ -521,9 +567,9 @@ export class ScrydexApiService implements IScrydexApiService {
         params.set('condition', condition);
       }
 
-      const response = await this.fetchWithRetry<
-        ScrydexPaginatedResponse<ScrydexListing>
-      >(`${this.baseUrl}/cards/${cardId}/listings?${params}`);
+      const response = await this.fetchPaginated<ScrydexListing>(
+        `${this.baseUrl}/cards/${cardId}/listings?${params}`
+      );
 
       console.log(
         `[ScrydexApiService] Retrieved ${response.data.length} listings for card ${cardId}`


### PR DESCRIPTION
## Problem

Sets and cards are truncated at 100 items. The Scrydex API returns pagination metadata in **snake_case** (`total_count`, `page_size`, `count`) but our `ScrydexPaginatedResponse` type expected **camelCase** (`totalCount`, `pageSize`).

This caused `response.totalCount` to resolve to `undefined`, making the pagination while-loop condition `items.length < undefined` evaluate to `false`, exiting after the first page every time.

**Evidence from raw API responses:**
- Expansions: `"total_count": 406` → we were getting 100
- Cards (tcgp-B1): `"total_count": 331` → we were getting 100

## Root Cause

Field name mismatch between the Scrydex API response shape and our TypeScript interface:

| API returns (snake_case) | Our type expected (camelCase) | Result |
|---|---|---|
| `total_count` | `totalCount` | `undefined` — loop exits after page 1 |
| `page_size` | `pageSize` | `undefined` — cosmetic only |
| `count` | *(missing)* | Lost field |

## Fix (Option C — remap at fetch boundary)

- Added `ScrydexRawPaginatedResponse` interface matching the actual API shape (snake_case)
- Added `mapPaginatedResponse()` helper for snake_case → camelCase conversion
- Added `fetchPaginated()` convenience method on the service class
- Updated `getAllExpansions`, `getCardsInExpansion`, `searchCards`, and `getCardListings` to use `fetchPaginated` instead of `fetchWithRetry` for paginated endpoints
- Kept `ScrydexPaginatedResponse` (camelCase) as the internal type used everywhere else
- Added `count` field to `ScrydexPaginatedResponse` (was missing)
- Improved pagination loop logging to show progress per page

## What this fixes

- Sets will load all ~406 expansions (was capped at 100)
- Cards for large sets (e.g. tcgp-B1 with 331 cards) will load completely
- Cosmos DB will self-heal: when Scrydex returns the full dataset, it gets saved back to Cosmos replacing the stale 100-card entries

## Testing

After deploy, verify:
1. Set dropdown shows all expansions (400+, not 100)
2. Large sets like tcgp-B1 (331 cards) and sv8/Surging Sparks (252 cards) return all cards
3. Check Vercel function logs for pagination progress lines: `Cards page 1: 100 items, 100/331 total` → `Cards page 4: 31 items, 331/331 total`

Closes #10