### PR TITLE
fix(portfolio): repair gh status panel rendering

### DIFF
--- a/apps/portfolio/src/lib/components/GhDashboard/LanguagesBar.svelte
+++ b/apps/portfolio/src/lib/components/GhDashboard/LanguagesBar.svelte
@@ -5,6 +5,9 @@
 	 * language colors. When `langs` is null, falls back to a muted bar +
 	 * skeleton legend.
 	 *
+	 * Bar + legend dots use inline SVG `fill` attributes (not CSS `style:`)
+	 * so the strict CSP `style-src 'self'` allows the runtime colors.
+	 *
 	 * Spec: §4 Modules → Languages bar.
 	 */
 
@@ -18,31 +21,43 @@
 	const { langs }: Props = $props();
 
 	const LEGEND_COUNT = 5;
+
+	const segments = $derived.by(() => {
+		if (!langs) return null;
+		let offset = 0;
+		return langs.map((lang) => {
+			const seg = { ...lang, offset };
+			offset += lang.pct;
+			return seg;
+		});
+	});
 </script>
 
 <div class="languages">
-	<div
+	<svg
 		class="bar"
+		viewBox="0 0 100 8"
+		preserveAspectRatio="none"
+		width="100%"
+		height="8"
 		role="img"
 		aria-label={langs
 			? `Language breakdown: ${langs.map((l) => `${l.name} ${l.pct}%`).join(', ')}`
 			: 'Language breakdown loading'}
 	>
-		{#if langs}
-			{#each langs as lang (lang.name)}
-				<span
-					class="segment"
-					style:width="{lang.pct}%"
-					style:background={lang.color}
-				></span>
+		{#if segments}
+			{#each segments as seg (seg.name)}
+				<rect x={seg.offset} y="0" width={seg.pct} height="8" fill={seg.color} />
 			{/each}
 		{/if}
-	</div>
+	</svg>
 	<ul class="legend">
 		{#if langs}
 			{#each langs as lang (lang.name)}
 				<li>
-					<span class="dot" style:background={lang.color}></span>
+					<svg class="dot" width="8" height="8" viewBox="0 0 8 8" aria-hidden="true">
+						<circle cx="4" cy="4" r="4" fill={lang.color} />
+					</svg>
 					<span class="name">{lang.name}</span>
 					<span class="pct">{lang.pct}%</span>
 				</li>
@@ -50,7 +65,7 @@
 		{:else}
 			{#each Array.from({ length: LEGEND_COUNT }) as _, i (i)}
 				<li>
-					<span class="dot"></span>
+					<span class="dot dot-skel"></span>
 					<Skeleton width="64px" height="0.7em" />
 				</li>
 			{/each}
@@ -70,11 +85,6 @@
 		border-radius: var(--radius-sm);
 		background: rgba(255, 255, 255, 0.05);
 		overflow: hidden;
-		display: flex;
-	}
-
-	.segment {
-		height: 100%;
 		display: block;
 	}
 
@@ -96,6 +106,10 @@
 	.dot {
 		width: 8px;
 		height: 8px;
+		flex-shrink: 0;
+	}
+
+	.dot-skel {
 		border-radius: 50%;
 		background: rgba(255, 255, 255, 0.15);
 	}

--- a/apps/portfolio/src/lib/components/GhDashboard/TopRepos.svelte
+++ b/apps/portfolio/src/lib/components/GhDashboard/TopRepos.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
 	/**
-	 * Top repos card — 4 repo rows showing name, description, primary
-	 * language dot, and star count. When `repos` is null, falls back to
-	 * skeleton placeholders.
+	 * Top repos card — featured repo rows showing name, description, and
+	 * primary language dot. When `repos` is null, falls back to skeleton
+	 * placeholders.
+	 *
+	 * Language dot uses inline SVG `fill` (not CSS `style:`) so the strict
+	 * CSP `style-src 'self'` allows the runtime color.
 	 *
 	 * Spec: §4 Modules → Top repos card.
 	 */
@@ -16,7 +19,7 @@
 
 	const { repos }: Props = $props();
 
-	const ROW_COUNT = 4;
+	const ROW_COUNT = 5;
 </script>
 
 <div class="card">
@@ -38,17 +41,22 @@
 					{#if repo.description}
 						<p class="desc">{repo.description}</p>
 					{/if}
-					<div class="meta">
-						{#if repo.language}
+					{#if repo.language}
+						<div class="meta">
 							<span class="lang">
-								<span class="lang-dot" style:background={repo.language.color}></span>
+								<svg
+									class="lang-dot"
+									width="8"
+									height="8"
+									viewBox="0 0 8 8"
+									aria-hidden="true"
+								>
+									<circle cx="4" cy="4" r="4" fill={repo.language.color} />
+								</svg>
 								{repo.language.name}
 							</span>
-						{/if}
-						<span class="stars" aria-label={`${repo.stars} stars`}>
-							★ {repo.stars}
-						</span>
-					</div>
+						</div>
+					{/if}
 				</li>
 			{/each}
 		{:else}
@@ -58,7 +66,6 @@
 					<Skeleton width="100%" height="0.8em" />
 					<div class="meta">
 						<Skeleton width="60px" height="0.7em" />
-						<Skeleton width="40px" height="0.7em" />
 					</div>
 				</li>
 			{/each}
@@ -138,12 +145,6 @@
 	}
 
 	.lang-dot {
-		width: 8px;
-		height: 8px;
-		border-radius: 50%;
-	}
-
-	.stars {
-		color: var(--dim);
+		flex-shrink: 0;
 	}
 </style>

--- a/apps/portfolio/src/lib/server/github.ts
+++ b/apps/portfolio/src/lib/server/github.ts
@@ -22,6 +22,17 @@ const GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql';
 const GITHUB_REST_BASE = 'https://api.github.com';
 const USER_AGENT = 'maber-web-portfolio/1.0 (+https://dev.maber.io)';
 
+// Curated featured repos for the Top Repos card. Order is preserved in the
+// rendered list. Update this array to swap, add, or remove repos — query
+// builder + response shape adapt automatically.
+const FEATURED_REPOS = [
+	'PCPC',
+	'maber-web',
+	'agent-dev',
+	'code-vector-sync',
+	'mom-cloud'
+] as const;
+
 export interface GhUser {
 	login: string;
 	repoCount: number;
@@ -38,7 +49,6 @@ export interface GhRepo {
 	name: string;
 	description: string | null;
 	url: string;
-	stars: number;
 	language: { name: string; color: string } | null;
 }
 
@@ -69,6 +79,32 @@ export type GhFetchResult =
 	| { ok: true; data: GhDashboardData }
 	| { ok: false; error: string };
 
+const REPO_FIELDS_FRAGMENT = /* GraphQL */ `
+	fragment RepoFields on Repository {
+		name
+		description
+		url
+		primaryLanguage {
+			name
+			color
+		}
+		languages(first: 10, orderBy: { field: SIZE, direction: DESC }) {
+			edges {
+				size
+				node {
+					name
+					color
+				}
+			}
+		}
+	}
+`;
+
+const FEATURED_REPO_LOOKUPS = FEATURED_REPOS.map(
+	(name, i) =>
+		`repo${i}: repository(owner: "${GITHUB_LOGIN}", name: "${name}") { ...RepoFields }`
+).join('\n\t\t');
+
 const QUERY = /* GraphQL */ `
 	query GhDashboard($login: String!) {
 		user(login: $login) {
@@ -91,36 +127,22 @@ const QUERY = /* GraphQL */ `
 				}
 			}
 		}
-		topRepos: user(login: $login) {
-			repositories(
-				first: 4
-				privacy: PUBLIC
-				isFork: false
-				orderBy: { field: STARGAZERS, direction: DESC }
-			) {
-				nodes {
-					name
-					description
-					url
-					stargazerCount
-					primaryLanguage {
-						name
-						color
-					}
-					languages(first: 10, orderBy: { field: SIZE, direction: DESC }) {
-						edges {
-							size
-							node {
-								name
-								color
-							}
-						}
-					}
-				}
-			}
-		}
+		${FEATURED_REPO_LOOKUPS}
 	}
+	${REPO_FIELDS_FRAGMENT}
 `;
+
+interface RepoNode {
+	name: string;
+	description: string | null;
+	url: string;
+	primaryLanguage: { name: string; color: string } | null;
+	languages: {
+		edges: { size: number; node: { name: string; color: string | null } }[];
+	};
+}
+
+type FeaturedReposResponse = Record<`repo${number}`, RepoNode | null>;
 
 interface GraphqlResponse {
 	data?: {
@@ -140,21 +162,7 @@ interface GraphqlResponse {
 				};
 			};
 		};
-		topRepos: {
-			repositories: {
-				nodes: {
-					name: string;
-					description: string | null;
-					url: string;
-					stargazerCount: number;
-					primaryLanguage: { name: string; color: string } | null;
-					languages: {
-						edges: { size: number; node: { name: string; color: string | null } }[];
-					};
-				}[];
-			};
-		};
-	};
+	} & FeaturedReposResponse;
 	errors?: { message: string }[];
 }
 
@@ -166,8 +174,8 @@ interface RestEvent {
 		commits?: { message: string }[];
 		ref_type?: string;
 		ref?: string | null;
-		pull_request?: { title: string; number: number };
-		issue?: { title: string; number: number };
+		pull_request?: { title?: string; number: number };
+		issue?: { title?: string; number: number };
 		action?: string;
 	};
 }
@@ -249,15 +257,18 @@ function shapeData(
 			}))
 	);
 
-	const topRepos: GhRepo[] = gql.topRepos.repositories.nodes.map((repo) => ({
+	const repoNodes: RepoNode[] = FEATURED_REPOS.map((_, i) => gql[`repo${i}`]).filter(
+		(node): node is RepoNode => node !== null && node !== undefined
+	);
+
+	const topRepos: GhRepo[] = repoNodes.map((repo) => ({
 		name: repo.name,
 		description: repo.description,
 		url: repo.url,
-		stars: repo.stargazerCount,
 		language: repo.primaryLanguage
 	}));
 
-	const languages = aggregateLanguages(gql.topRepos.repositories.nodes);
+	const languages = aggregateLanguages(repoNodes);
 	const recentActivity = filterEvents(events);
 
 	return {
@@ -274,9 +285,7 @@ function shapeData(
 	};
 }
 
-function aggregateLanguages(
-	repos: NonNullable<GraphqlResponse['data']>['topRepos']['repositories']['nodes']
-): GhLanguage[] {
+function aggregateLanguages(repos: RepoNode[]): GhLanguage[] {
 	const totals = new Map<string, { bytes: number; color: string }>();
 
 	for (const repo of repos) {
@@ -339,14 +348,16 @@ function messageFor(ev: RestEvent): string {
 			// Commits often have multi-line bodies; keep the subject only.
 			return commit.split('\n', 1)[0];
 		}
-		case 'PullRequestEvent':
-			return ev.payload.pull_request
-				? `#${ev.payload.pull_request.number} ${ev.payload.pull_request.title}`
-				: '';
-		case 'IssuesEvent':
-			return ev.payload.issue
-				? `#${ev.payload.issue.number} ${ev.payload.issue.title}`
-				: '';
+		case 'PullRequestEvent': {
+			const pr = ev.payload.pull_request;
+			if (!pr) return '';
+			return pr.title ? `#${pr.number} ${pr.title}` : `#${pr.number}`;
+		}
+		case 'IssuesEvent': {
+			const issue = ev.payload.issue;
+			if (!issue) return '';
+			return issue.title ? `#${issue.number} ${issue.title}` : `#${issue.number}`;
+		}
 		case 'CreateEvent':
 			return ev.payload.ref_type === 'repository'
 				? 'created repository'


### PR DESCRIPTION
## Summary

Fixes five rendering issues on the GhDashboard panel surfaced from a screenshot of the live site:

- **Top Repos lineup**: replaced the `STARGAZERS DESC` query (meaningless when every repo has 0 stars) with a curated `FEATURED_REPOS` allowlist via aliased GraphQL `repository()` lookups: PCPC, maber-web, agent-dev, code-vector-sync, mom-cloud. Eliminates the profile-readme leak (`Abernaughty/Abernaughty`) by construction.
- **Languages bar / dots**: switched from Svelte `style:` directives (which compile to inline `style=""` attributes — blocked by `style-src 'self'`) to inline SVG `<rect fill={...}>` and `<circle fill={...}>`. SVG presentation attributes aren't subject to `style-src`, so colors come through under the strict CSP.
- **PR title `undefined`**: guarded `messageFor()` against missing `pull_request.title` / `issue.title`. Row degrades to bare `#34` instead of `#34 undefined`.
- **Star counts removed**: every repo had `★ 0`; the display only highlighted the absence. Dropped from `GhRepo`, the GraphQL fragment, and the response mapping.
- **TopRepos `ROW_COUNT`** bumped to 5 to match the curated lineup.

## Test plan

- [x] `pnpm check` passes (1 pre-existing CSS warning, unrelated)
- [x] Vite dev preview renders 5 top-repo skeleton rows; clean console
- [ ] On Vercel preview deploy: confirm Top Repos shows the 5 curated entries with descriptions + colored language dots
- [ ] On Vercel preview deploy: confirm Languages bar shows colored stacked segments matching legend
- [ ] On Vercel preview deploy: confirm browser console has no `Refused to apply inline style because it violates the following Content Security Policy directive` warnings
- [ ] On Vercel preview deploy: confirm Recent Activity PR row reads `#N <real title>` (or bare `#N`), never `#N undefined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)